### PR TITLE
Change: rename libKitsunemimiHanamiMessaging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -103,7 +103,7 @@ echo "##########################################################################
 echo ""
 get_required_private_repo_github "libKitsunemimiHanamiCommon" "develop" 8
 get_required_private_repo_github "libKitsunemimiHanamiEndpoints" "develop" 1
-get_required_private_repo_github "libKitsunemimiHanamiMessaging" "develop" 8
+get_required_private_repo_github "libKitsunemimiHanamiNetwork" "develop" 8
 download_private_repo_github "libKitsunemimiHanamiMessages" "develop"
 echo ""
 echo "###########################################################################################################"

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -28,8 +28,8 @@
 
 #include <libKitsunemimiHanamiCommon/component_support.h>
 #include <libKitsunemimiHanamiCommon/structs.h>
-#include <libKitsunemimiHanamiMessaging/hanami_messaging.h>
-#include <libKitsunemimiHanamiMessaging/hanami_messaging_client.h>
+#include <libKitsunemimiHanamiNetwork/hanami_messaging.h>
+#include <libKitsunemimiHanamiNetwork/hanami_messaging_client.h>
 
 using Kitsunemimi::Hanami::HanamiMessaging;
 using Kitsunemimi::Hanami::HanamiMessagingClient;

--- a/src/other.cpp
+++ b/src/other.cpp
@@ -28,8 +28,8 @@
 
 #include <libKitsunemimiHanamiCommon/component_support.h>
 #include <libKitsunemimiHanamiCommon/structs.h>
-#include <libKitsunemimiHanamiMessaging/hanami_messaging.h>
-#include <libKitsunemimiHanamiMessaging/hanami_messaging_client.h>
+#include <libKitsunemimiHanamiNetwork/hanami_messaging.h>
+#include <libKitsunemimiHanamiNetwork/hanami_messaging_client.h>
 
 using Kitsunemimi::Hanami::HanamiMessaging;
 using Kitsunemimi::Hanami::HanamiMessagingClient;

--- a/src/snapshots.cpp
+++ b/src/snapshots.cpp
@@ -24,8 +24,8 @@
 #include <libSagiriArchive/sagiri_messages.h>
 
 #include <libKitsunemimiHanamiCommon/component_support.h>
-#include <libKitsunemimiHanamiMessaging/hanami_messaging.h>
-#include <libKitsunemimiHanamiMessaging/hanami_messaging_client.h>
+#include <libKitsunemimiHanamiNetwork/hanami_messaging.h>
+#include <libKitsunemimiHanamiNetwork/hanami_messaging_client.h>
 
 #include <../../libKitsunemimiHanamiMessages/hanami_messages/sagiri_messages.h>
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -65,10 +65,10 @@ LIBS += -L../../libKitsunemimiHanamiCommon/src/debug -lKitsunemimiHanamiCommon
 LIBS += -L../../libKitsunemimiHanamiCommon/src/release -lKitsunemimiHanamiCommon
 INCLUDEPATH += ../../libKitsunemimiHanamiCommon/include
 
-LIBS += -L../../libKitsunemimiHanamiMessaging/src -lKitsunemimiHanamiMessaging
-LIBS += -L../../libKitsunemimiHanamiMessaging/src/debug -lKitsunemimiHanamiMessaging
-LIBS += -L../../libKitsunemimiHanamiMessaging/src/release -lKitsunemimiHanamiMessaging
-INCLUDEPATH += ../../libKitsunemimiHanamiMessaging/include
+LIBS += -L../../libKitsunemimiHanamiNetwork/src -lKitsunemimiHanamiMessaging
+LIBS += -L../../libKitsunemimiHanamiNetwork/src/debug -lKitsunemimiHanamiMessaging
+LIBS += -L../../libKitsunemimiHanamiNetwork/src/release -lKitsunemimiHanamiMessaging
+INCLUDEPATH += ../../libKitsunemimiHanamiNetwork/include
 
 LIBS += -lssl -lcryptopp -lcrypto
 

--- a/tests/unit_tests/unit_tests.pro
+++ b/tests/unit_tests/unit_tests.pro
@@ -79,10 +79,10 @@ LIBS += -L../../../libKitsunemimiCommon/src/debug -lKitsunemimiCommon
 LIBS += -L../../../libKitsunemimiCommon/src/release -lKitsunemimiCommon
 INCLUDEPATH += ../../../libKitsunemimiCommon/include
 
-LIBS += -L../../../libKitsunemimiHanamiMessaging/src -lKitsunemimiHanamiMessaging
-LIBS += -L../../../libKitsunemimiHanamiMessaging/src/debug -lKitsunemimiHanamiMessaging
-LIBS += -L../../../libKitsunemimiHanamiMessaging/src/release -lKitsunemimiHanamiMessaging
-INCLUDEPATH += ../../../libKitsunemimiHanamiMessaging/include
+LIBS += -L../../../libKitsunemimiHanamiNetwork/src -lKitsunemimiHanamiMessaging
+LIBS += -L../../../libKitsunemimiHanamiNetwork/src/debug -lKitsunemimiHanamiMessaging
+LIBS += -L../../../libKitsunemimiHanamiNetwork/src/release -lKitsunemimiHanamiMessaging
+INCLUDEPATH += ../../../libKitsunemimiHanamiNetwork/include
 
 LIBS += -lssl -lcryptopp -lcrypto
 


### PR DESCRIPTION
## Description

Change: rename libKitsunemimiHanamiMessaging

## Related Issues

- https://github.com/kitsudaiki/KitsumiAI/issues/8

## How it was tested?

- ci-pipeline