### PR TITLE
Add: add move fields to result-push-messages

### DIFF
--- a/include/libSagiriArchive/other.h
+++ b/include/libSagiriArchive/other.h
@@ -40,6 +40,9 @@ namespace Sagiri
 {
 
 bool sendResults(const std::string &uuid,
+                 const std::string &name,
+                 const std::string &userId,
+                 const std::string &projectId,
                  const Kitsunemimi::DataArray &results,
                  Kitsunemimi::ErrorContainer &error);
 

--- a/include/libSagiriArchive/sagiri_messages.h
+++ b/include/libSagiriArchive/sagiri_messages.h
@@ -100,6 +100,9 @@ public:
     ~ResultPush_Message();
 
     std::string uuid = "";
+    std::string name = "";
+    std::string userId = "";
+    std::string projectId = "";
     std::string results;
 
     bool read(void* data, const uint64_t dataSize);

--- a/src/other.cpp
+++ b/src/other.cpp
@@ -42,6 +42,7 @@ namespace Sagiri
  * @brief send list with request-results to sagiri
  *
  * @param uuid uuid of the request-task
+ * @param name name of the request-task
  * @param results data-array with results
  * @param error reference for error-output
  *
@@ -49,6 +50,9 @@ namespace Sagiri
  */
 bool
 sendResults(const std::string &uuid,
+            const std::string &name,
+            const std::string &userId,
+            const std::string &projectId,
             const Kitsunemimi::DataArray &results,
             Kitsunemimi::ErrorContainer &error)
 {
@@ -57,11 +61,17 @@ sendResults(const std::string &uuid,
         return false;
     }
 
+    // fill message
     ResultPush_Message msg;
     msg.uuid = uuid;
+    msg.name = name;
+    msg.userId = userId;
+    msg.projectId = projectId;
     msg.results = results.toString();
-    uint8_t buffer[96*1024];
-    const uint64_t size = msg.createBlob(buffer, 96*1024);
+
+    // TODO: variable size
+    uint8_t buffer[1024*1024];
+    const uint64_t size = msg.createBlob(buffer, 1024*1024);
 
     Kitsunemimi::DataBuffer* ret = client->sendGenericRequest(buffer, size, error);
     delete ret;

--- a/src/sagiri_messages.cpp
+++ b/src/sagiri_messages.cpp
@@ -260,6 +260,15 @@ ResultPush_Message::read(void* data, const uint64_t dataSize)
     if(readString(data, uuid) == false) {
         return false;
     }
+    if(readString(data, name) == false) {
+        return false;
+    }
+    if(readString(data, userId) == false) {
+        return false;
+    }
+    if(readString(data, projectId) == false) {
+        return false;
+    }
     if(readString(data, results) == false) {
         return false;
     }
@@ -276,8 +285,11 @@ uint64_t
 ResultPush_Message::createBlob(uint8_t* result, const uint64_t bufferSize)
 {
     const uint64_t totalMsgSize = sizeof(MessageHeader)
-                                  + 2 * sizeof(Entry)
+                                  + 5 * sizeof(Entry)
                                   + uuid.size()
+                                  + name.size()
+                                  + userId.size()
+                                  + projectId.size()
                                   + results.size();
 
     if(bufferSize < totalMsgSize) {
@@ -287,6 +299,9 @@ ResultPush_Message::createBlob(uint8_t* result, const uint64_t bufferSize)
     uint64_t pos = 0;
     pos += initBlob(&result[pos], totalMsgSize);
     pos += appendString(&result[pos], uuid);
+    pos += appendString(&result[pos], name);
+    pos += appendString(&result[pos], userId);
+    pos += appendString(&result[pos], projectId);
     pos += appendString(&result[pos], results);
 
     assert(pos == totalMsgSize);


### PR DESCRIPTION
## Description

Add: add move fields to result-push-messages

## Related Issues

- https://github.com/kitsudaiki/SagiriArchive/issues/7

## How it was tested?

- Tsugumi
